### PR TITLE
Remove incorrect double-escape of quotes in winrm commands

### DIFF
--- a/lib/vagrant-winrm/commands/winrm.rb
+++ b/lib/vagrant-winrm/commands/winrm.rb
@@ -49,7 +49,6 @@ module VagrantPlugins
 
           options[:command].each do |c|
             @logger.debug("Executing command: #{c}")
-            c.gsub! '"', '\"' if c.include? '`' or c.include? '$(' # Powershell is so strange sometimes!
             exit_code |= vm.communicate.execute(c) do |type, data|
               $stdout.print data if type == :stdout
               $stderr.print data if type == :stderr


### PR DESCRIPTION
I'm not sure what this line is here to work around, but I found it breaks several commands that I send through winrm.

For example:

```
$env:PATH="$env:PATH;c:\foo"
$env:FOO=$(bar)
```

The quotes on the first line would be double-escaped and the command blows up.

I could not find an example of a command that went wrong after removing this line, provided commands were correctly escaped on the vagrant command line. (For example, by using 'shellescape' in Ruby)
