### PR TITLE
Add ability to run with local eleavated credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a [Vagrant][vagrant_dl] 1.6+ plugin that adds new command to extends Win
 
 ## <a name="features"></a> Features
 
-* Execute remote command
+* Execute remote command (even with elevated credentials)
 * Upload files
 * Retrieve WinRM configuration
 
@@ -25,6 +25,9 @@ Please read the [Plugin usage][plugin_usage] page for more details.
 This command allows you to execute arbitrary remote commands through WinRM.
 
     vagrant winrm -c "pre-install.bat" -c "install.bat" -c "post-install.bat" Windows2008VM
+
+The following command run the given command with local elevated credentials
+    vagrant winrm -e -c "winrm get winrm/config Windows2008VM
 
 ### <a name="usage-winrm-upload"> winrm-upload
 

--- a/lib/vagrant-winrm/commands/winrm.rb
+++ b/lib/vagrant-winrm/commands/winrm.rb
@@ -20,6 +20,10 @@ module VagrantPlugins
             options[:command].push c
           end
 
+          o.on('-e', '--elevated', 'Run all commands with elevated credentials') do |e|
+            options[:elevated] = true
+          end
+
           o.on('-s', '--shell SHELL', [:powershell, :cmd], 'Use the specified shell (powershell, cmd)') do |s|
             options[:shell] = s
           end
@@ -51,7 +55,7 @@ module VagrantPlugins
 
           options[:command].each do |c|
             @logger.debug("Executing command: #{c}")
-            exit_code |= vm.communicate.execute(c, shell: options[:shell]) { |type, data| (type == :stderr ? $stderr : $stdout).print data }
+            exit_code |= vm.communicate.execute(c, shell: options[:shell], elevated: options[:elevated]) { |type, data| (type == :stderr ? $stderr : $stdout).print data }
           end
           return exit_code
         end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module VagrantWinRM
-    VERSION = '0.4.0'
+    VERSION = '0.5.0'
   end
 end

--- a/spec/vagrant-winrm/commands/winrm_config_spec.rb
+++ b/spec/vagrant-winrm/commands/winrm_config_spec.rb
@@ -37,7 +37,7 @@ describe VagrantPlugins::VagrantWinRM::WinRMConfig, :unit => true do
     end
 
     # Add our machine to the environment
-    allow(env).to receive(:machine).with(any_args, :virtualbox) do |name, provider|
+    allow(env).to receive(:machine) do |name, provider|
       machine if :vagrant == name
     end
   end

--- a/spec/vagrant-winrm/commands/winrm_upload_spec.rb
+++ b/spec/vagrant-winrm/commands/winrm_upload_spec.rb
@@ -28,7 +28,7 @@ describe VagrantPlugins::VagrantWinRM::WinRMUpload, :unit => true do
     end
 
     # Add our machine to the environment
-    allow(env).to receive(:machine).with(any_args, :virtualbox) do |name, provider|
+    allow(env).to receive(:machine) do |name, provider|
       machine if :vagrant == name
     end
   end


### PR DESCRIPTION
In order to run some commands, it could be usefull to leverage the vagrant winrm communicator feature: "elevated shell".
* Add the option -e to run all commands as elevated shell.