### PR TITLE
use vagrant helper to fetch winrm config

### DIFF
--- a/lib/vagrant-winrm/commands/winrm_config.rb
+++ b/lib/vagrant-winrm/commands/winrm_config.rb
@@ -30,8 +30,8 @@ module VagrantPlugins
 
           variables = {
             host_key: options[:host] || machine.name || 'vagrant',
-            winrm_host: machine.config.winrm.host,
-            winrm_port: machine.config.winrm.port,
+            winrm_host: VagrantPlugins::CommunicatorWinRM::Helper.winrm_info(machine)[:host],
+            winrm_port: VagrantPlugins::CommunicatorWinRM::Helper.winrm_info(machine)[:port],
             winrm_user: machine.config.winrm.username,
             winrm_password: machine.config.winrm.password
           }

--- a/lib/vagrant-winrm/commands/winrm_config.rb
+++ b/lib/vagrant-winrm/commands/winrm_config.rb
@@ -1,5 +1,6 @@
 require 'optparse'
 require 'vagrant/util/safe_puts'
+require 'vagrant/../../plugins/communicators/winrm/helper'
 
 module VagrantPlugins
   module VagrantWinRM


### PR DESCRIPTION
For some boxes, `vagrant winrm-config` returns the wrong port and host information. Specifically, it will generally return 5985 because that is the port on which winrm is running on the guest. But (for a local vagrant box) if winrm is already running on the host, that port gets reassigned in the collision fix during port forwarding. The winrm_info helper takes this into account.

This ensures that the information returned by `winrm-config` is the same information that vagrant is actually using in its own communicator.