### PR TITLE
Add RDPPort to `vagrant winrm-config`

### DIFF
--- a/lib/vagrant-winrm/commands/winrm_config.rb
+++ b/lib/vagrant-winrm/commands/winrm_config.rb
@@ -34,7 +34,8 @@ module VagrantPlugins
             winrm_host: VagrantPlugins::CommunicatorWinRM::Helper.winrm_info(machine)[:host],
             winrm_port: VagrantPlugins::CommunicatorWinRM::Helper.winrm_info(machine)[:port],
             winrm_user: machine.config.winrm.username,
-            winrm_password: machine.config.winrm.password
+            winrm_password: machine.config.winrm.password,
+            rdp_port: machine.config.rdp.port
           }
 
           # Render the template and output directly to STDOUT

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,8 +19,13 @@ def mock_env
       allow(config).to receive(:[]) { |key| config.send(key) }
     end
   }
+  let(:rdp_config) {
+    double('rdp_config', port: 4321, search_port: 98765).tap do |config|
+      allow(config).to receive(:[]) { |key| config.send(key) }
+    end
+  }
   let(:config_vm) { double('config_vm', communicator: :winrm) }
-  let(:machine_config) { double('machine_config', winrm: winrm_config, vm: config_vm) }
+  let(:machine_config) { double('machine_config', winrm: winrm_config, rdp: rdp_config, vm: config_vm) }
 
   let(:provider) {
     double('provider', to_sym: :virtualbox).tap do |provider|

--- a/spec/vagrant-winrm/commands/winrm_config_spec.rb
+++ b/spec/vagrant-winrm/commands/winrm_config_spec.rb
@@ -59,6 +59,7 @@ describe VagrantPlugins::VagrantWinRM::WinRMConfig, :unit => true do
         expect($stdout.string).to match(/#{winrm_config.port}/)
         expect($stdout.string).to match(/#{winrm_config.username}/)
         expect($stdout.string).to match(/#{winrm_config.password}/)
+        expect($stdout.string).to match(/#{rdp_config.port}/)
       ensure
         $stdout = STDOUT
       end
@@ -74,6 +75,7 @@ describe VagrantPlugins::VagrantWinRM::WinRMConfig, :unit => true do
         expect($stdout.string).to match(/#{winrm_config.port}/)
         expect($stdout.string).to match(/#{winrm_config.username}/)
         expect($stdout.string).to match(/#{winrm_config.password}/)
+        expect($stdout.string).to match(/#{rdp_config.port}/)
       ensure
         $stdout = STDOUT
       end
@@ -89,6 +91,7 @@ describe VagrantPlugins::VagrantWinRM::WinRMConfig, :unit => true do
         expect($stdout.string).to match(/#{winrm_config.port}/)
         expect($stdout.string).to match(/#{winrm_config.username}/)
         expect($stdout.string).to match(/#{winrm_config.password}/)
+        expect($stdout.string).to match(/#{rdp_config.port}/)
       ensure
         $stdout = STDOUT
       end

--- a/templates/winrm_config/config.erb
+++ b/templates/winrm_config/config.erb
@@ -3,3 +3,4 @@ Host <%= host_key %>
   Port <%= winrm_port %>
   User <%= winrm_user %>
   Password <%= winrm_password %>
+  RDPPort <%= rdp_port %>


### PR DESCRIPTION
Hello, and thank you for this Vagrant plugin, it is exactly what I was going to sit down and write this afternoon.

I'd like to use this plugin to support the [Vagrant Driver](https://github.com/test-kitchen/kitchen-vagrant) for [Test Kitchen](http://kitchen.ci/) when dealing with Windows instances. You can take a peek at test-kitchen/kitchen-vagrant#155 if you want to see what I'm using this for.

Test Kitchen has a `kitchen login` method, not unlike `vagrant ssh` or recently `vagrant rdp`, and as we're all still waiting for WinRM Remoting from non-Windows systems, it seems like launching an RDP session is the thing to do in the meantime.

I'm wondering how receptive this project would be to adding/exposing the RDP Port to the `vagrant winrm-config` data hash. The name and/or implementation may not be 100%, but I wanted to see what an implementation looked like (and I have to solve this problem anyway for Test Kitchen). Thoughts?

Thanks again!