### PR TITLE
consistent behaviour of `-c` across `vagrant ssh` and `vagrant winrm`

### DIFF
--- a/lib/vagrant-winrm/commands/winrm.rb
+++ b/lib/vagrant-winrm/commands/winrm.rb
@@ -55,7 +55,7 @@ module VagrantPlugins
 
           options[:command].each do |c|
             @logger.debug("Executing command: #{c}")
-            exit_code |= vm.communicate.execute(c, shell: options[:shell], elevated: options[:elevated]) { |type, data| (type == :stderr ? $stderr : $stdout).print data }
+            exit_code |= vm.communicate.execute(c, shell: options[:shell], elevated: options[:elevated], error_check: false) { |type, data| (type == :stderr ? $stderr : $stdout).print data }
           end
           return exit_code
         end


### PR DESCRIPTION
Addresses https://github.com/criteo/vagrant-winrm/issues/14 by turning `error_check` off - this allows the original error code to be returned to the system without error - which looks like the original intent of the code anyway, otherwise `exit_code` must always be one.

I couldn't get the rspec tests to run properly before or after applying this fix - probably rubygem related.

After applying the fix, behaviour is consistent with `vagrant ssh -c`:

```shell
$ vagrant winrm -c 'puppet apply --detailed-exitcodes -e "notify{foo:}"'
echo $?
Notice: Compiled catalog for win-d47651bpuuq in environment production in 0.06 seconds
Notice: foo
Notice: /Stage[main]/Main/Notify[foo]/message: defined 'message' as 'foo'
Notice: Applied catalog in 0.02 seconds
$ echo $?
2
```

